### PR TITLE
Personalized feed name and subtitle + do not show non-public entries

### DIFF
--- a/rstblog/builder.py
+++ b/rstblog/builder.py
@@ -24,7 +24,8 @@ from werkzeug import url_unquote
 
 from rstblog.signals import before_file_processed, \
      before_template_rendered, before_build_finished, \
-     before_file_built, after_file_prepared
+     before_file_built, after_file_prepared, \
+     after_file_published
 from rstblog.modules import find_module
 from rstblog.programs import RSTProgram, CopyProgram
 
@@ -58,10 +59,16 @@ class Context(object):
         if prepare:
             self.program.prepare()
             after_file_prepared.send(self)
+            if self.public:
+                after_file_published.send(self)
 
     @property
     def is_new(self):
         return not os.path.exists(self.full_destination_filename)
+
+    @property
+    def public(self):
+        return self.config.get('public', True)
 
     @property
     def slug(self):

--- a/rstblog/modules/blog.py
+++ b/rstblog/modules/blog.py
@@ -18,7 +18,7 @@ from jinja2 import contextfunction
 from werkzeug.routing import Rule, Map, NotFound
 from werkzeug.contrib.atom import AtomFeed
 
-from rstblog.signals import after_file_prepared, \
+from rstblog.signals import after_file_published, \
      before_build_finished
 from rstblog.utils import Pagination
 
@@ -146,8 +146,10 @@ def write_archive_pages(builder):
 def write_feed(builder):
     blog_author = builder.config.root_get('author')
     url = builder.config.root_get('canonical_url') or 'http://localhost/'
-    feed = AtomFeed(u'Recent Blog Posts',
-                    subtitle=u'Recent blog posts',
+    name = builder.config.get('feed.name') or u'Recent Blog Posts'
+    subtitle = builder.config.get('feed.subtitle') or u'Recent blog posts'
+    feed = AtomFeed(name,
+                    subtitle=subtitle,
                     feed_url=urljoin(url, builder.link_to('blog_feed')),
                     url=url)
     for entry in get_all_entries(builder)[:10]:
@@ -166,7 +168,7 @@ def write_blog_files(builder):
 
 
 def setup(builder):
-    after_file_prepared.connect(process_blog_entry)
+    after_file_published.connect(process_blog_entry)
     before_build_finished.connect(write_blog_files)
     builder.register_url('blog_index', config_key='modules.blog.index_url',
                          config_default='/', defaults={'page': 1})

--- a/rstblog/modules/tags.py
+++ b/rstblog/modules/tags.py
@@ -15,7 +15,7 @@ from jinja2 import contextfunction
 
 from werkzeug.contrib.atom import AtomFeed
 
-from rstblog.signals import after_file_prepared, \
+from rstblog.signals import after_file_published, \
      before_build_finished
 
 
@@ -75,8 +75,10 @@ def write_tagcloud_page(builder):
 def write_tag_feed(builder, tag):
     blog_author = builder.config.root_get('author')
     url = builder.config.root_get('canonical_url') or 'http://localhost/'
-    feed = AtomFeed(u'Recent Blog Posts',
-                    subtitle=u'Recent blog posts',
+    name = builder.config.get('feed.name') or u'Recent Blog Posts'
+    subtitle = builder.config.get('feed.subtitle') or u'Recent blog posts'
+    feed = AtomFeed(name,
+                    subtitle=subtitle,
                     feed_url=urljoin(url, builder.link_to('blog_feed')),
                     url=url)
     for entry in get_tagged_entries(builder, tag)[:10]:
@@ -107,7 +109,7 @@ def write_tag_files(builder):
 
 
 def setup(builder):
-    after_file_prepared.connect(remember_tags)
+    after_file_published.connect(remember_tags)
     before_build_finished.connect(write_tag_files)
     builder.register_url('tag', config_key='modules.tags.tag_url',
                          config_default='/tags/<tag>/')

--- a/rstblog/signals.py
+++ b/rstblog/signals.py
@@ -21,6 +21,9 @@ before_file_processed = signals.signal('before_file_processed')
 #: after the file was prepared
 after_file_prepared = signals.signal('after_file_prepared')
 
+#: after the file was published (public: yes)
+after_file_published = signals.signal('after_file_published')
+
 #: fired the moment before a template is rendered with the context object
 #: that is about to be passed to the template.
 before_template_rendered = signals.signal('before_template_rendered')


### PR DESCRIPTION
I have added another signal "after_file_published" not to show non-public entries in entries list, archives, feeds, tags.
Entries in this state are still published but hidden from all pages.
