### PR TITLE
Make simple installs work.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,6 @@ setup(
     entry_points = {
         'console_scripts': ['run-rstblog = rstblog.cli:main'],
     },
+    include_package_data=True,
     install_requires=['PyYAML', 'Babel', 'blinker', 'Jinja2>=2.4', 'Werkzeug']
 )


### PR DESCRIPTION
As a test, I tried to clone the lucumr-repository and run-rstblog on it, installed in a virtualenv. I ran into two issues:
1. Outdated Jinja2 version (no version requirement in setup.py).
2. Templates not included in build (include_package_data not enabled in setup.py).

Here are two patches to fix these problems. Afterwards, I was able to create a fresh virtualenv, install rstblog to it with pip, then run it on the lucumr-repository.
