### PR TITLE
Add external module structure like sphinxcontrib

### DIFF
--- a/rstblog/builder.py
+++ b/rstblog/builder.py
@@ -221,6 +221,11 @@ class Builder(object):
             mod.setup(self)
             self.modules.append(mod)
 
+        for extension in self.config.root_get('extensions') or []:
+            mod = __import__(extension, None, None, ['setup'])
+            mod.setup(self)
+            self.modules.append(mod)
+
     @property
     def default_output_folder(self):
         return os.path.join(self.project_folder,


### PR DESCRIPTION
Hi,

Currently rstblog need to put extra module into `modules` directroy.

For example when I create module like `youtube.py`, which shows thumbnail in blog, I put it into `modules` directory manually.

IMHO third party module should not put into `rstblog.modules` directry.

So I wrote a patch, which can handle external module structure like `sphinxcontrib`.

Here is a sample config.yml

```

---
active_modules: [pygments, tags, blog, latex]
extensions: [rstblogcontrib.youtube]
modules:
  pygments:
    style: tango
```
1. Add `extensions` list in config.yml.
2. `./run-rstblog build` execute `rstblogcontrib.youtube.setup()`.

If you don't need any extensions, delete `extensions` line, so rstblog would not execute extensions.

Please check it and include.

Regards,
