### PR TITLE
Allow a build program to be an external command

### DIFF
--- a/rstblog/builder.py
+++ b/rstblog/builder.py
@@ -28,7 +28,7 @@ from rstblog.signals import before_file_processed, \
      before_file_built, after_file_prepared, \
      after_file_published
 from rstblog.modules import find_module
-from rstblog.programs import RSTProgram, CopyProgram
+from rstblog.programs import RSTProgram, CopyProgram, ExecProgram
 
 
 OUTPUT_FOLDER = '_build'
@@ -55,7 +55,10 @@ class Context(object):
         if self.program_name is None:
             self.program_name = self.builder.guess_program(
                 config, source_filename)
-        self.program = self.builder.programs[self.program_name](self)
+        if self.program_name.startswith('!'):
+            self.program = ExecProgram(self, self.program_name[1:])
+        else:
+            self.program = self.builder.programs[self.program_name](self)
         self.destination_filename = os.path.join(
             self.builder.prefix_path.lstrip('/'),
             self.program.get_desired_filename())


### PR DESCRIPTION
This allows custom build commands to be specified for files without
needing to extend rstblog for every external command that you might want
to run.  External commands start with an exclamation mark and must have
two arguments which begin with a percent sign - these are the input and
output file names in order.

Filename arguments are allowed to have a suffix so that file extensions
can be changed, for example by adding the follwing to a "config.yml"
file in a directory, files in that directory are compiled by "lessc" and
".less" files are renamed to ".css":

```
program: "!lessc %.less %.css"
```

Please let me know if you think there's a better way to accomplish this - this
seems sensible to me but it's quite possible that I've missed a neater way
to do this.

John
