### PR TITLE
Include templates in install.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ setup(
     version='1.0',
     author='Armin Ronacher <armin.ronacher@active-4.com>',
     packages=['rstblog', 'rstblog.modules'],
+    include_package_data=True,
     description='',
     long_description='',
     license='BSD License',


### PR DESCRIPTION
This just ensures that the default templates are actually installed when rstblog is installed normally (i.e. not editable/develop).

Pull request #17 was initially intended for this same purpose, but has accumulated unrelated changes.
