### PR TITLE
Support for language variable

### DIFF
--- a/rstblog/builder.py
+++ b/rstblog/builder.py
@@ -74,6 +74,10 @@ class Context(object):
         return self.config.get('public', True)
 
     @property
+    def language(self):
+        return self.config.get('language') or self.config.root_get('language', 'en')
+
+    @property
     def slug(self):
         directory, filename = os.path.split(self.source_filename)
         basename, ext = os.path.splitext(filename)


### PR DESCRIPTION
Support for "language" config variable in config.yml and blogpost header.

Can be used for `<html lang="[language]">` Tag (relevant e.g. if you want language-specific hyphenation).

I used the following template code:

```
<html lang="{% if ctx and ctx.language %}{{ ctx.language }}{% else %}en{%endif %}">
```
