### PR TITLE
Predictable ordering of content files in same directory.

### DIFF
--- a/rstblog/builder.py
+++ b/rstblog/builder.py
@@ -318,7 +318,7 @@ class Builder(object):
             dirnames[:] = self.filter_files(dirnames, local_config)
             filenames = self.filter_files(filenames, local_config)
 
-            for filename in filenames:
+            for filename in sorted(filenames):
                 yield Context(self, local_config, os.path.join(
                     dirpath[cutoff:], filename), prepare)
 


### PR DESCRIPTION
If multiple content files are in the same directory (e.g. two blog posts on same day) their ordering is currently dependent on some factors that I haven't fully bothered to track down, but that ordering can differ between different people working on the same rstblog site, which can cause spurious differences in output.

This is easily fixed, and the ordering made deterministic, by just sorting filenames in a given directory.
